### PR TITLE
Qskwood patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I use this to ping my servers and wake them up if they are off.  They should nev
 
 `cronetab -e`
 
-`@reboot bash /home/pi/power-on-server.sh > power-on-server.log`
+`@hourly bash /home/pi/power-on-server.sh > power-on-server.log`
 (will run at reboot and will pipe out logs)
 
 Requires `etherwake` and `wakeonlan` (apt-get).

--- a/power-on-server.sh
+++ b/power-on-server.sh
@@ -10,8 +10,7 @@ HOSTNUM=0
 HOSTS=(192.168.0.1 192.168.0.2 192.168.0.3)
 HOSTSDOWN=false
 MACADDRS=(mac.address.1 mac.address.2 mac.address.3)
-#PING="/bin/ping -q -c1"
-PING=false
+PING="/bin/ping -q -c1"
 WAITTIME=10
 
 ### functions

--- a/power-on-server.sh
+++ b/power-on-server.sh
@@ -27,6 +27,7 @@ function wake_up() {
 for HOST in ${HOSTS[*]}; do
   if ! ${PING} ${HOST} > /dev/null
   then
+    HOSTSDOWN=true
     echo "${HOST} is down $(date)"
     # try to wake
     wake_up ${HOSTNUM}
@@ -48,9 +49,13 @@ for HOST in ${HOSTS[*]}; do
     HOSTNUM=$(($HOSTNUM+1))
   else
     echo "${HOST} was up at $(date)"
+    HOSTSDOWN=false
   fi
 done
 
 # reboot
-#echo "Pi is rebooting"
-#/sbin/shutdown -r now
+if ${HOSTSDOWN}
+  then
+  echo "Pi is rebooting"
+fi
+/sbin/shutdown -r now

--- a/power-on-server.sh
+++ b/power-on-server.sh
@@ -8,7 +8,7 @@
 
 HOSTNUM=0
 HOSTS=(192.168.0.1 192.168.0.2 192.168.0.3)
-HOSTSDOWN=false
+HOSTSDOWN=0
 MACADDRS=(mac.address.1 mac.address.2 mac.address.3)
 PING="/bin/ping -q -c1"
 WAITTIME=10
@@ -27,7 +27,7 @@ function wake_up() {
 for HOST in ${HOSTS[*]}; do
   if ! ${PING} ${HOST} > /dev/null
   then
-    HOSTSDOWN=true
+    HOSTSDOWN=$((${HOSTSDOWN}+1))
     echo "${HOST} is down $(date)"
     # try to wake
     wake_up ${HOSTNUM}
@@ -49,12 +49,11 @@ for HOST in ${HOSTS[*]}; do
     HOSTNUM=$(($HOSTNUM+1))
   else
     echo "${HOST} was up at $(date)"
-    HOSTSDOWN=false
   fi
 done
 
 # reboot
-if ${HOSTSDOWN}
+if [[ ${HOSTSDOWN} -eq ${#HOSTS[@]} ]]
   then
   echo "Pi is rebooting"
 fi


### PR DESCRIPTION
The script now loops through hosts, first pinging them to see if they're up then trying to wake them up if they're not up.

If every host is down, clearly something is wrong so the Pi reboots.

Alternatively, this could be set to `@reboot` in cron and the Pi could just reboot every time it finishes the script, but I thought that might not be desirable.